### PR TITLE
Add OpenSearch

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -1,3 +1,7 @@
+<head>
+	<link rel="search" type="application/opensearchdescription+xml" href="opensearch.xml" title="IOTA Sear.ch" />
+</head>
+<body>
 <h1 class="text-center">IOTA Tangle Explorer</h1>
 <p>Search the Iota Tangle for a transaction hash, address, or bundle hash using the search box above. </p>
 <div class="row">
@@ -104,3 +108,4 @@
 </table>
 </div>
 </div>
+	</body>

--- a/html/opensearch.xml
+++ b/html/opensearch.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>IOTA Sear.ch</ShortName>
+  <Image width="16" height="16">https://iotasear.ch/favicon.ico</Image>
+  <Url type="text/html" template="https://iotasear.ch/search/{searchTerms}" />
+  <Tags></Tags>
+</OpenSearchDescription>


### PR DESCRIPTION
OpenSearch lets lazy people (like me) search a website from the Chrome Omnibox. All you have to do is type the beginning of the URL (e.g. iotase), press tab, and then paste in the hash and it will automatically search the website.